### PR TITLE
feat: `get_diff_duration` between two Timestamps

### DIFF
--- a/src/ntp64.rs
+++ b/src/ntp64.rs
@@ -9,10 +9,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 use humantime::{format_rfc3339_nanos, parse_rfc3339};
-use std::fmt;
 use std::ops::{Add, AddAssign, Sub};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{fmt, ops::SubAssign};
 
 // maximal number of seconds that can be represented in the 32-bits part
 const MAX_NB_SEC: u64 = (1u64 << 32) - 1;
@@ -129,6 +129,49 @@ impl Sub for NTP64 {
     #[inline]
     fn sub(self, other: Self) -> Self {
         Self(self.0 - other.0)
+    }
+}
+
+impl<'a> Sub<NTP64> for &'a NTP64 {
+    type Output = <NTP64 as Sub<NTP64>>::Output;
+
+    #[inline]
+    fn sub(self, other: NTP64) -> <NTP64 as Sub<NTP64>>::Output {
+        Sub::sub(*self, other)
+    }
+}
+
+impl Sub<&NTP64> for NTP64 {
+    type Output = <NTP64 as Sub<NTP64>>::Output;
+
+    #[inline]
+    fn sub(self, other: &NTP64) -> <NTP64 as Sub<NTP64>>::Output {
+        Sub::sub(self, *other)
+    }
+}
+
+impl Sub<&NTP64> for &NTP64 {
+    type Output = <NTP64 as Sub<NTP64>>::Output;
+
+    #[inline]
+    fn sub(self, other: &NTP64) -> <NTP64 as Sub<NTP64>>::Output {
+        Sub::sub(*self, *other)
+    }
+}
+
+impl Sub<u64> for NTP64 {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: u64) -> Self {
+        Self(self.0 - other)
+    }
+}
+
+impl SubAssign<u64> for NTP64 {
+    #[inline]
+    fn sub_assign(&mut self, other: u64) {
+        *self = Self(self.0 - other);
     }
 }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 use super::{ID, NTP64};
-use std::{fmt, ops::Add, ops::Sub};
+use std::fmt;
 use std::{str::FromStr, time::Duration};
 
 /// A timestamp made of a [`NTP64`] and a [`crate::HLC`]'s unique identifier.

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -9,8 +9,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 use super::{ID, NTP64};
-use std::fmt;
 use std::str::FromStr;
+use std::{fmt, ops::Add, ops::Sub};
 
 /// A timestamp made of a [`NTP64`] and a [`crate::HLC`]'s unique identifier.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -71,6 +71,70 @@ impl FromStr for Timestamp {
     }
 }
 
+impl Add for Timestamp {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: Self) -> Self::Output {
+        Self {
+            time: self.time + other.time,
+            id: if self.id > other.id {
+                self.id
+            } else {
+                other.id
+            },
+        }
+    }
+}
+
+impl Add<&Timestamp> for &Timestamp {
+    type Output = Timestamp;
+
+    #[inline]
+    fn add(self, other: &Timestamp) -> Self::Output {
+        Timestamp {
+            time: self.time + other.time,
+            id: if self.id > other.id {
+                self.id.clone()
+            } else {
+                other.id.clone()
+            },
+        }
+    }
+}
+
+impl Sub for Timestamp {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: Self) -> Self::Output {
+        Self {
+            time: self.time - other.time,
+            id: if self.id > other.id {
+                self.id
+            } else {
+                other.id
+            },
+        }
+    }
+}
+
+impl Sub<&Timestamp> for &Timestamp {
+    type Output = Timestamp;
+
+    #[inline]
+    fn sub(self, other: &Timestamp) -> Self::Output {
+        Timestamp {
+            time: self.time + other.time,
+            id: if self.id > other.id {
+                self.id.clone()
+            } else {
+                other.id.clone()
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseTimestampError {
     pub cause: String,
@@ -101,7 +165,7 @@ mod tests {
 
         let now = system_time_clock();
         let ts1_now = Timestamp::new(now, id1);
-        let ts2_now = Timestamp::new(now, id2);
+        let ts2_now = Timestamp::new(now, id2.clone());
         assert_ne!(ts1_now, ts2_now);
         assert!(ts1_now < ts2_now);
         assert!(ts1_epoch < ts1_now);
@@ -109,5 +173,11 @@ mod tests {
 
         let s = ts1_now.to_string();
         assert_eq!(ts1_now, s.parse().unwrap());
+
+        let add_ts = &ts1_now + &ts2_now;
+        assert_eq!(add_ts, Timestamp::new(now + now, id2.clone()));
+
+        let sub_ts = ts1_now - ts2_now;
+        assert_eq!(sub_ts, Timestamp::new(NTP64(0), id2));
     }
 }


### PR DESCRIPTION
Should I implement Add and Sub for:
- `impl Add<&Timestamp> for Timestamp`
- `impl<'a> Add<Timestamp> for &'a Timestamp`

as well?