### PR TITLE
no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,23 @@ categories = ["date-and-time"]
 authors = ["Julien Enoch <julien.enoch@adlinktech.com>"]
 edition = "2018"
 
+[features]
+default = ["std"]
+std = ["uuid/std", "hex/std", "humantime", "log/std", "lazy_static", "serde/std"]
+nightly = ["error_in_core"] # Enables experimental features -- requires nightly rust toolchain
+error_in_core = [] # Allows to use core::error::Error
+
 [dependencies]
-uuid = { version = "1.1", features = ["v4"] }
-hex = "0.4"
-humantime = "2.0"
-log = "0.4"
-lazy_static = "1.4.0"
-serde = { version = "1.0", features = ["derive"] }
+uuid = { version = "1.1", default-features = false, features = ["v4"] }
+    # NOTE: Generation of UUIDv4 on embedded devices requires a custom implementation
+    #       for getrandom::getrandom. Refer to the following page for more information:
+    #       https://docs.rs/getrandom/latest/getrandom/#unsupported-targets
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+humantime = { version = "2.0", optional = true }
+log = { version = "0.4", default-features = false }
+lazy_static = { version = "1.4.0", optional = true }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+spin = { version = "0.9", default-features = false, features = ["mutex", "use_ticket_mutex"] } # No_std alternative for std::sync::Mutex
 
 [dev-dependencies]
 futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ humantime = { version = "2.0", optional = true }
 log = { version = "0.4", default-features = false }
 lazy_static = { version = "1.4.0", optional = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-spin = { version = "0.9", default-features = false, features = ["mutex", "use_ticket_mutex"] } # No_std alternative for std::sync::Mutex
+spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
 
 [dev-dependencies]
 futures = "0.3"

--- a/src/id.rs
+++ b/src/id.rs
@@ -8,13 +8,13 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
-use serde::{Deserialize, Serialize};
 use core::cmp::Ordering;
 use core::convert::{TryFrom, TryInto};
 use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::num::NonZeroU128;
 use core::str::FromStr;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[cfg(not(feature = "std"))]
@@ -154,7 +154,8 @@ impl TryFrom<&[u8]> for ID {
         }
         let mut id = 0u128;
         unsafe {
-            core::mem::transmute::<&mut u128, &mut [u8; 16]>(&mut id)[..size].copy_from_slice(slice);
+            core::mem::transmute::<&mut u128, &mut [u8; 16]>(&mut id)[..size]
+                .copy_from_slice(slice);
             match NonZeroU128::new(id) {
                 Some(id) => Ok(Self(id)),
                 None => Err(SizeError(0)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,12 +51,29 @@
     html_root_url = "https://atolab.github.io/uhlc-rs/"
 )]
 
-use lazy_static::lazy_static;
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![cfg_attr(feature = "error_in_core", feature(error_in_core))]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use log::warn;
-use std::cmp;
-use std::env::var;
-use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use core::cmp;
+use core::time::Duration;
+
+#[cfg(feature = "std")]
+use {
+    lazy_static::lazy_static,
+    std::env::var,
+    std::sync::Mutex,
+    std::time::{SystemTime, UNIX_EPOCH},
+};
+
+#[cfg(not(feature = "std"))]
+use {
+    alloc::{format, string::String},
+    spin::Mutex, // No_std-friendly alternative to std::sync::Mutex
+};
 
 mod id;
 pub use id::*;
@@ -77,6 +94,7 @@ const LMASK: u64 = !CMASK;
 // HLC Delta in milliseconds: maximum accepted drift for an external timestamp.
 // I.e.: if an incoming timestamp has a time > now() + delta, then the HLC is not updated.
 const DEFAULT_DELTA_MS: u64 = 500;
+#[cfg(feature = "std")]
 lazy_static! {
     static ref DELTA_MS: u64 = match var("UHLC_MAX_DELTA_MS") {
         Ok(s) => s.parse().unwrap_or_else(|e| panic!(
@@ -90,6 +108,8 @@ lazy_static! {
         ),
     };
 }
+#[cfg(not(feature = "std"))]
+static DELTA_MS: &u64 = &DEFAULT_DELTA_MS; // Environment variables do not make sense in no_std environment
 
 ///
 /// The builder of [`HLC`].
@@ -166,7 +186,10 @@ impl Default for HLCBuilder {
         HLCBuilder {
             hlc: HLC {
                 id: uuid::Uuid::new_v4().into(),
+                #[cfg(feature = "std")]
                 clock: system_time_clock,
+                #[cfg(not(feature = "std"))]
+                clock: zero_clock,
                 delta: NTP64::from(Duration::from_millis(*DELTA_MS)),
                 last_time: Default::default(),
             },
@@ -182,6 +205,7 @@ pub struct HLC {
     last_time: Mutex<NTP64>,
 }
 
+#[cfg(feature = "std")]
 macro_rules! lock {
     ($var:expr) => {
         match $var.try_lock() {
@@ -189,6 +213,11 @@ macro_rules! lock {
             Err(_) => $var.lock().unwrap(),
         }
     };
+}
+
+#[cfg(not(feature = "std"))]
+macro_rules! lock {
+    ($var:expr) => { $var.lock() }
 }
 
 impl HLC {
@@ -306,8 +335,18 @@ impl Default for HLC {
 /// That's the default clock used by an [`HLC`] if [`HLCBuilder::with_clock()`] is not called.
 ///
 #[inline]
+#[cfg(feature = "std")]
 pub fn system_time_clock() -> NTP64 {
     NTP64::from(SystemTime::now().duration_since(UNIX_EPOCH).unwrap())
+}
+
+/// A dummy clock that returns a NTP64 initialized with the value 0.
+/// Suitable to use in no_std environments where std::time::{SystemTime, UNIX_EPOCH} are not available.
+/// If the feature `std` is disabled, that's the default clock used by an [`HLC`] if [`HLCBuilder::with_clock()`] is not called.
+/// Notice that this means that the [`HLC`] will use incremental timestamps starting from 0.
+#[inline]
+pub fn zero_clock() -> NTP64 {
+    NTP64(0)
 }
 
 #[cfg(test)]
@@ -316,8 +355,8 @@ mod tests {
     use async_std::sync::Arc;
     use async_std::task;
     use futures::join;
-    use std::convert::TryFrom;
-    use std::time::Duration;
+    use core::convert::TryFrom;
+    use core::time::Duration;
 
     fn is_sorted(vec: &[Timestamp]) -> bool {
         let mut it = vec.iter();
@@ -441,9 +480,9 @@ mod tests {
 
     #[test]
     fn stack_sizes() {
-        assert_eq!(std::mem::size_of::<ID>(), 16);
-        assert_eq!(std::mem::size_of::<Option<ID>>(), 16);
-        assert_eq!(std::mem::size_of::<Timestamp>(), 24);
-        assert_eq!(std::mem::size_of::<Option<Timestamp>>(), 24);
+        assert_eq!(core::mem::size_of::<ID>(), 16);
+        assert_eq!(core::mem::size_of::<Option<ID>>(), 16);
+        assert_eq!(core::mem::size_of::<Timestamp>(), 24);
+        assert_eq!(core::mem::size_of::<Option<Timestamp>>(), 24);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,16 +50,18 @@
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
     html_root_url = "https://atolab.github.io/uhlc-rs/"
 )]
-
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(all(not(feature = "std"), feature = "error_in_core"), feature(error_in_core))] // core::error::Error is not needed if using std
+#![cfg_attr(
+    all(not(feature = "std"), feature = "error_in_core"),
+    feature(error_in_core)
+)] // core::error::Error is not needed if using std
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-use log::warn;
 use core::cmp;
 use core::time::Duration;
+use log::warn;
 
 #[cfg(feature = "std")]
 use {
@@ -217,7 +219,9 @@ macro_rules! lock {
 
 #[cfg(not(feature = "std"))]
 macro_rules! lock {
-    ($var:expr) => { $var.lock() }
+    ($var:expr) => {
+        $var.lock()
+    };
 }
 
 impl HLC {
@@ -354,9 +358,9 @@ mod tests {
     use crate::*;
     use async_std::sync::Arc;
     use async_std::task;
-    use futures::join;
     use core::convert::TryFrom;
     use core::time::Duration;
+    use futures::join;
 
     fn is_sorted(vec: &[Timestamp]) -> bool {
         let mut it = vec.iter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 )]
 
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(feature = "error_in_core", feature(error_in_core))]
+#![cfg_attr(all(not(feature = "std"), feature = "error_in_core"), feature(error_in_core))] // core::error::Error is not needed if using std
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/src/ntp64.rs
+++ b/src/ntp64.rs
@@ -8,16 +8,16 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
-use serde::{Deserialize, Serialize};
+use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::time::Duration;
-use core::fmt;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use {
+    core::str::FromStr,
     humantime::{format_rfc3339_nanos, parse_rfc3339},
     std::time::{SystemTime, UNIX_EPOCH},
-    core::str::FromStr,
 };
 
 #[cfg(not(feature = "std"))]

--- a/src/ntp64.rs
+++ b/src/ntp64.rs
@@ -8,12 +8,20 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
-use humantime::{format_rfc3339_nanos, parse_rfc3339};
 use serde::{Deserialize, Serialize};
-use std::ops::{Add, AddAssign, Sub};
-use std::str::FromStr;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use std::{fmt, ops::SubAssign};
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::time::Duration;
+use core::fmt;
+
+#[cfg(feature = "std")]
+use {
+    humantime::{format_rfc3339_nanos, parse_rfc3339},
+    std::time::{SystemTime, UNIX_EPOCH},
+    core::str::FromStr,
+};
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 
 // maximal number of seconds that can be represented in the 32-bits part
 const MAX_NB_SEC: u64 = (1u64 << 32) - 1;
@@ -67,6 +75,7 @@ impl NTP64 {
 
     /// Convert to a [`SystemTime`] (making the assumption that this NTP64 is relative to [`UNIX_EPOCH`]).
     #[inline]
+    #[cfg(feature = "std")]
     pub fn to_system_time(self) -> SystemTime {
         UNIX_EPOCH + self.to_duration()
     }
@@ -178,7 +187,10 @@ impl SubAssign<u64> for NTP64 {
 
 impl fmt::Display for NTP64 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", format_rfc3339_nanos(self.to_system_time()))
+        #[cfg(feature = "std")]
+        return write!(f, "{}", format_rfc3339_nanos(self.to_system_time()));
+        #[cfg(not(feature = "std"))]
+        return write!(f, "{:x}", self.0);
     }
 }
 
@@ -197,6 +209,7 @@ impl From<Duration> for NTP64 {
     }
 }
 
+#[cfg(feature = "std")]
 impl FromStr for NTP64 {
     type Err = ParseNTP64Error;
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -10,7 +10,13 @@
 //
 use super::{ID, NTP64};
 use serde::{Deserialize, Serialize};
-use std::{fmt, str::FromStr, time::Duration};
+use core::{fmt, time::Duration};
+
+#[cfg(feature = "std")]
+use core::str::FromStr;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 
 /// A timestamp made of a [`NTP64`] and a [`crate::HLC`]'s unique identifier.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -57,6 +63,7 @@ impl fmt::Debug for Timestamp {
     }
 }
 
+#[cfg(feature = "std")]
 impl FromStr for Timestamp {
     type Err = ParseTimestampError;
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -9,8 +9,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 use super::{ID, NTP64};
-use serde::{Deserialize, Serialize};
 use core::{fmt, time::Duration};
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::str::FromStr;


### PR DESCRIPTION
First attempt at `no_std` support. `std` is enabled by default (as a Cargo feature), but can be disabled if needed.