### PR TITLE
Logging in `no_std` (+ minor test fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,21 +26,30 @@ edition = "2018"
 
 [features]
 default = ["std"]
-std = ["uuid/std", "hex/std", "humantime", "log/std", "lazy_static", "serde/std"]
+std = [
+    "hex/std",
+    "humantime",
+    "lazy_static",
+    "log/std",
+    "serde/std",
+    "uuid/std"
+]
+defmt = ["dep:defmt"] # Enables defmt for logging in no_std
 nightly = ["error_in_core"] # Enables experimental features -- requires nightly rust toolchain
 error_in_core = [] # Allows to use core::error::Error
 
 [dependencies]
+defmt = { version = "0.3.2", features = ["alloc"], optional = true }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
+humantime = { version = "2.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
+log = { version = "0.4", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
 uuid = { version = "1.1", default-features = false, features = ["v4"] }
     # NOTE: Generation of UUIDv4 on embedded devices requires a custom implementation
     #       for getrandom::getrandom. Refer to the following page for more information:
     #       https://docs.rs/getrandom/latest/getrandom/#unsupported-targets
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-humantime = { version = "2.0", optional = true }
-log = { version = "0.4", default-features = false }
-lazy_static = { version = "1.4.0", optional = true }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
 
 [dev-dependencies]
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ This crate provides the following Cargo features:
  * `std`: allows this crate to use the full `std`. Even if disabled, notice that the
    `alloc` crate is still required;
 
+ * `defmt`: allows the relevant data structures to implement the `defmt::Format` trait,
+   used instead of `std::fmt::{Debug, Display}` for logging in `no_std` environments;
+
  * `nightly`: allows to enable all the experimental features at once;
 
  * `error_in_core`: experimental feature (requires Rust nightly toolchain) that enables

--- a/src/id.rs
+++ b/src/id.rs
@@ -95,6 +95,17 @@ impl fmt::Display for SizeError {
         )
     }
 }
+#[cfg(feature = "defmt")]
+impl defmt::Format for SizeError {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "Maximum ID size ({} bytes) exceeded: {}",
+            ID::MAX_SIZE,
+            self.0
+        );
+    }
+}
 
 #[cfg(feature = "std")]
 impl std::error::Error for SizeError {}
@@ -204,6 +215,13 @@ impl fmt::Display for ID {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for ID {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}", hex::encode_upper(self.as_slice()));
+    }
+}
+
 impl FromStr for ID {
     type Err = ParseIDError;
 
@@ -221,6 +239,7 @@ impl FromStr for ID {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ParseIDError {
     pub cause: String,
 }

--- a/src/ntp64.rs
+++ b/src/ntp64.rs
@@ -200,6 +200,13 @@ impl fmt::Debug for NTP64 {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for NTP64 {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{:x}", self.0);
+    }
+}
+
 impl From<Duration> for NTP64 {
     fn from(duration: Duration) -> NTP64 {
         let secs = duration.as_secs();
@@ -229,6 +236,7 @@ impl FromStr for NTP64 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ParseNTP64Error {
     pub cause: String,
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -143,7 +143,7 @@ mod tests {
 
         #[cfg(feature = "std")]
         {
-            // We do not case about parsing human-readable timestamps in no_std
+            // We do not care about parsing human-readable timestamps in no_std
             let s = ts1_now.to_string();
             assert_eq!(ts1_now, s.parse().unwrap());
         }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -63,6 +63,13 @@ impl fmt::Debug for Timestamp {
     }
 }
 
+#[cfg(feature = "defmt")]
+impl defmt::Format for Timestamp {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(f, "{}/{}", self.time, self.id);
+    }
+}
+
 #[cfg(feature = "std")]
 impl FromStr for Timestamp {
     type Err = ParseTimestampError;
@@ -85,6 +92,7 @@ impl FromStr for Timestamp {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(deature = "defmt", derive(defmt::Format))]
 pub struct ParseTimestampError {
     pub cause: String,
 }
@@ -93,7 +101,6 @@ pub struct ParseTimestampError {
 mod tests {
     use crate::*;
     use std::convert::TryFrom;
-    use std::time::UNIX_EPOCH;
 
     #[test]
     fn test_timestamp() {
@@ -101,29 +108,34 @@ mod tests {
         let id2: ID = ID::try_from([0x02]).unwrap();
 
         let ts1_epoch = Timestamp::new(Default::default(), id1);
-        assert_eq!(ts1_epoch.get_time().to_system_time(), UNIX_EPOCH);
+        #[cfg(feature = "std")]
+        assert_eq!(ts1_epoch.get_time().to_system_time(), std::time::UNIX_EPOCH);
         assert_eq!(ts1_epoch.get_id(), &id1);
 
         let ts2_epoch = Timestamp::new(Default::default(), id2);
-        assert_eq!(ts2_epoch.get_time().to_system_time(), UNIX_EPOCH);
+        #[cfg(feature = "std")]
+        assert_eq!(ts2_epoch.get_time().to_system_time(), std::time::UNIX_EPOCH);
         assert_eq!(ts2_epoch.get_id(), &id2);
 
         // Test that 2 Timestamps with same time but different ids are different and ordered
         assert_ne!(ts1_epoch, ts2_epoch);
         assert!(ts1_epoch < ts2_epoch);
 
-        let now = system_time_clock();
-        let ts1_now = Timestamp::new(now, id1);
-        let ts2_now = Timestamp::new(now, id2);
-        assert_ne!(ts1_now, ts2_now);
-        assert!(ts1_now < ts2_now);
-        assert!(ts1_epoch < ts1_now);
-        assert!(ts2_epoch < ts2_now);
+        #[cfg(feature = "std")]
+        {
+            let now = system_time_clock();
+            let ts1_now = Timestamp::new(now, id1);
+            let ts2_now = Timestamp::new(now, id2);
+            assert_ne!(ts1_now, ts2_now);
+            assert!(ts1_now < ts2_now);
+            assert!(ts1_epoch < ts1_now);
+            assert!(ts2_epoch < ts2_now);
 
-        let s = ts1_now.to_string();
-        assert_eq!(ts1_now, s.parse().unwrap());
+            let s = ts1_now.to_string();
+            assert_eq!(ts1_now, s.parse().unwrap());
 
-        let diff = ts1_now.get_diff_duration(&ts2_now);
-        assert_eq!(diff, Duration::from_secs(0));
+            let diff = ts1_now.get_diff_duration(&ts2_now);
+            assert_eq!(diff, Duration::from_secs(0));
+        }
     }
 }


### PR DESCRIPTION
`defmt` is a library commonly used to log information via a serial communication when developing on `no_std` targets. Data structures need to implement the `defmt::Format` trait in order to be "printable" by `defmt`. With this PR, I added an opt-in (because of usually tight size constraints) `defmt` feature that enables the relevant data structures to implement such trait.

Additionally, I fixed a small problem with `Timestamp` tests when the `std` feature is disabled (i.e. a test case was using a method defined only when `std` is enabled).