### PR TITLE
Removed nightly features + `derive(defmt::Format)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,18 @@ std = [
     "hex/std",
     "humantime",
     "lazy_static",
-    "log/std",
+    "log",
     "serde/std",
     "uuid/std"
 ]
 defmt = ["dep:defmt"] # Enables defmt for logging in no_std
 
 [dependencies]
-defmt = { version = "0.3.2", features = ["alloc"], optional = true }
+defmt = { version = "0.3.2", features = ["alloc"], optional = true } # Replaces log in no_std
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 humantime = { version = "2.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
-log = { version = "0.4", default-features = false }
+log = { version = "0.4", optional = true } # Used only in std
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
 uuid = { version = "1.1", default-features = false, features = ["v4"] }
@@ -50,7 +50,5 @@ uuid = { version = "1.1", default-features = false, features = ["v4"] }
     #       https://docs.rs/getrandom/latest/getrandom/#unsupported-targets
 
 [dev-dependencies]
+async-std = "1.6"
 futures = "0.3"
-
-[dev-dependencies.async-std]
-version = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,6 @@ std = [
     "uuid/std"
 ]
 defmt = ["dep:defmt"] # Enables defmt for logging in no_std
-nightly = ["error_in_core"] # Enables experimental features -- requires nightly rust toolchain
-error_in_core = [] # Allows to use core::error::Error
 
 [dependencies]
 defmt = { version = "0.3.2", features = ["alloc"], optional = true }

--- a/README.md
+++ b/README.md
@@ -101,13 +101,7 @@ This crate provides the following Cargo features:
    `alloc` crate is still required;
 
  * `defmt`: allows the relevant data structures to implement the `defmt::Format` trait,
-   used instead of `std::fmt::{Debug, Display}` for logging in `no_std` environments;
-
- * `nightly`: allows to enable all the experimental features at once;
-
- * `error_in_core`: experimental feature (requires Rust nightly toolchain) that enables
-   the usage of the trait `core::error::Error` instead of `std::error::Error`. Does nothing
-   if `std` is also enabled.
+   used instead of `std::fmt::{Debug, Display}` for logging in `no_std` environments.
 
 Only the `std` feature is enabled by default.
 
@@ -134,10 +128,8 @@ with respect to the `std` implementation include:
    by `spin::Mutex`, which is based on spinlocks instead of relying on some operating system
    functionality;
 
- * since `core::error::Error` is still an experimental feature in Rust, `SizeError`
-   can implement the `Error` trait only if the feature `error_in_core` is enabled;
-
- * tests (with `cargo test`) can be run only on `std` targets.
+ * tests (with `cargo test`) can be run only on `std` targets, but different code is compiled
+   (and hence tested) depending on the features specified.
 
 ## Usages
 **uhlc** is currently used in [Eclipse zenoh](https://github.com/eclipse-zenoh/zenoh).

--- a/src/id.rs
+++ b/src/id.rs
@@ -46,6 +46,7 @@ use alloc::string::{String, ToString};
 /// assert_eq!(id.size(), 16);
 /// ```
 #[derive(Copy, Clone, Eq, Deserialize, Serialize, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ID(NonZeroU128);
 
 impl ID {
@@ -84,6 +85,7 @@ impl From<Uuid> for ID {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SizeError(usize);
 impl fmt::Display for SizeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -93,17 +95,6 @@ impl fmt::Display for SizeError {
             ID::MAX_SIZE,
             self.0
         )
-    }
-}
-#[cfg(feature = "defmt")]
-impl defmt::Format for SizeError {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(
-            f,
-            "Maximum ID size ({} bytes) exceeded: {}",
-            ID::MAX_SIZE,
-            self.0
-        );
     }
 }
 
@@ -210,13 +201,6 @@ impl fmt::Debug for ID {
 impl fmt::Display for ID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self, f)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for ID {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}", hex::encode_upper(self.as_slice()));
     }
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -84,7 +84,7 @@ impl From<Uuid> for ID {
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct SizeError(usize);
+pub struct SizeError(pub usize);
 impl fmt::Display for SizeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/src/id.rs
+++ b/src/id.rs
@@ -109,8 +109,6 @@ impl defmt::Format for SizeError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for SizeError {}
-#[cfg(all(not(feature = "std"), feature = "error_in_core"))]
-impl core::error::Error for SizeError {}
 
 macro_rules! impl_from_sized_slice_for_id {
     ($N: expr) => {

--- a/src/id.rs
+++ b/src/id.rs
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
+use alloc::string::{String, ToString};
 use core::cmp::Ordering;
 use core::convert::{TryFrom, TryInto};
 use core::fmt;
@@ -16,9 +17,6 @@ use core::num::NonZeroU128;
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-
-#[cfg(not(feature = "std"))]
-use alloc::string::{String, ToString};
 
 /// An identifier for an HLC ([MAX_SIZE](ID::MAX_SIZE) bytes maximum).
 /// This struct has a constant memory size (holding internally a `[u8; MAX_SIZE]` + a `NonZeroU8`),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,6 @@
     html_root_url = "https://atolab.github.io/uhlc-rs/"
 )]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![cfg_attr(
-    all(not(feature = "std"), feature = "error_in_core"),
-    feature(error_in_core)
-)] // core::error::Error is not needed if using std
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,14 +50,12 @@
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
     html_root_url = "https://atolab.github.io/uhlc-rs/"
 )]
-#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-
-#[cfg(not(feature = "std"))]
+#![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
+use alloc::{format, string::String};
 use core::cmp;
 use core::time::Duration;
-use log::warn;
 
 #[cfg(feature = "std")]
 use {
@@ -68,10 +66,7 @@ use {
 };
 
 #[cfg(not(feature = "std"))]
-use {
-    alloc::{format, string::String},
-    spin::Mutex, // No_std-friendly alternative to std::sync::Mutex
-};
+use spin::Mutex; // No_std-friendly alternative to std::sync::Mutex
 
 mod id;
 pub use id::*;
@@ -303,7 +298,10 @@ impl HLC {
                 msg_time,
                 now
             );
-            warn!("{}", err_msg);
+            #[cfg(feature = "std")]
+            log::warn!("{}", err_msg);
+            #[cfg(feature = "defmt")]
+            defmt::warn!("{}", err_msg);
             Err(err_msg)
         } else {
             let mut last_time = lock!(self.last_time);
@@ -372,6 +370,7 @@ mod tests {
 
     #[test]
     fn hlc_parallel() {
+        use alloc::vec::Vec;
         task::block_on(async {
             let id0: ID = ID::try_from([0x01]).unwrap();
             let id1: ID = ID::try_from([0x02]).unwrap();

--- a/src/ntp64.rs
+++ b/src/ntp64.rs
@@ -8,6 +8,7 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
+use alloc::string::String;
 use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::time::Duration;
@@ -19,9 +20,6 @@ use {
     humantime::{format_rfc3339_nanos, parse_rfc3339},
     std::time::{SystemTime, UNIX_EPOCH},
 };
-
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
 
 // maximal number of seconds that can be represented in the 32-bits part
 const MAX_NB_SEC: u64 = (1u64 << 32) - 1;

--- a/src/ntp64.rs
+++ b/src/ntp64.rs
@@ -45,6 +45,7 @@ const NANO_PER_SEC: u64 = 1_000_000_000;
 /// define an EPOCH. Only the [`NTP64::to_system_time()`] and [`std::fmt::Display::fmt()`] operations assume that
 /// it's relative to UNIX_EPOCH (1st Jan 1970) to display the timpestamp in RFC-3339 format.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Deserialize, Serialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NTP64(pub u64);
 
 impl NTP64 {
@@ -197,13 +198,6 @@ impl fmt::Display for NTP64 {
 impl fmt::Debug for NTP64 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:x}", self.0)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for NTP64 {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{:x}", self.0);
     }
 }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -20,6 +20,7 @@ use alloc::string::String;
 
 /// A timestamp made of a [`NTP64`] and a [`crate::HLC`]'s unique identifier.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Timestamp {
     time: NTP64,
     id: ID,
@@ -60,13 +61,6 @@ impl fmt::Display for Timestamp {
 impl fmt::Debug for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}/{:?}", self.time, self.id)
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for Timestamp {
-    fn format(&self, f: defmt::Formatter) {
-        defmt::write!(f, "{}/{}", self.time, self.id);
     }
 }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -9,14 +9,12 @@
 // SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 //
 use super::{ID, NTP64};
+use alloc::string::String;
 use core::{fmt, time::Duration};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "std")]
 use core::str::FromStr;
-
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
 
 /// A timestamp made of a [`NTP64`] and a [`crate::HLC`]'s unique identifier.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -94,7 +92,7 @@ pub struct ParseTimestampError {
 #[cfg(test)]
 mod tests {
     use crate::*;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn test_timestamp() {


### PR DESCRIPTION
Changes in this PR:
- removed the nightly features we shouldn't be using in Zenoh anymore (as discussed);
- shifted to using derived implementations for `defmt::Format` instead of custom ones, in order to avoid code duplication.