### PR TITLE
CI check for `no_std`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,26 @@ jobs:
         run: |
           cargo doc --all --no-deps
           echo '<meta http-equiv=refresh content=0;url=uhlc/index.html>' > ./target/doc/index.html
+
+  nostd:
+    name: Run no_std checks
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install nightly Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: x86_64-unknown-none # Generic no_std target architecture
+          override: true
+      
+      - name: Perform no_std checks
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --bin nostd_check --target x86_64-unknown-none --manifest-path ci/nostd-check/Cargo.toml

--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/ci/nostd-check/Cargo.toml
+++ b/ci/nostd-check/Cargo.toml
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2022 ZettaScale Technology
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+# which is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+#
+# Contributors:
+#   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+#
+[package]
+name = "nostd-check"
+version = "0.1.0"
+repository = "https://github.com/atolab/uhlc-rs"
+homepage = "https://crates.io/crates/uhlc"
+authors = [
+  "Davide Della Giustina <davide.dellagiustina@zettascale.tech>",
+]
+edition = "2018"
+license = "EPL-2.0 OR Apache-2.0"
+categories = ["date-and-time"]
+description = "Internal crate for uhlc."
+
+[dependencies]
+getrandom = { version = "0.2.8", features = ["custom"] }
+linked_list_allocator = "0.10.4" # Needs nightly toolchain
+uhlc = { path = "../../", default-features = false }
+
+[[bin]]
+name = "nostd_check"
+path = "src/bin/nostd_check.rs"

--- a/ci/nostd-check/rust-toolchain.toml
+++ b/ci/nostd-check/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/ci/nostd-check/src/bin/nostd_check.rs
+++ b/ci/nostd-check/src/bin/nostd_check.rs
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2017, 2020 ADLINK Technology Inc.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+
+#![no_std]
+
+use core::panic::PanicInfo;
+use getrandom::{register_custom_getrandom, Error};
+use linked_list_allocator::LockedHeap;
+#[allow(unused_imports)]
+use uhlc;
+
+#[panic_handler]
+fn dummy_panic_handler(_: &PanicInfo) -> ! {
+    loop {}
+}
+
+#[global_allocator]
+static ALLOCATOR: LockedHeap = LockedHeap::empty();
+
+fn dummy_get_rand(_: &mut [u8]) -> Result<(), Error> {
+    Ok(())
+}
+
+fn main() {
+    register_custom_getrandom!(dummy_get_rand);
+}


### PR DESCRIPTION
Added a CI action to perform checks for the `no_std` version of this library. Unfortunately, building for a `no_std` target requires some stuff (randomness source, allocator, panic handler) to be defined by a root crate, so I added a dummy `main` for the purpose. Structure is the same adopted [here](https://github.com/eclipse-zenoh/zenoh/pull/439).