### PR TITLE
Remove UUID support from uhlc::ID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ std = [
     "lazy_static",
     "log",
     "serde/std",
-    "uuid/std"
 ]
 defmt = ["dep:defmt"] # Enables defmt for logging in no_std
 
@@ -42,12 +41,9 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 humantime = { version = "2.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = { version = "0.4", optional = true } # Used only in std
+rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
-uuid = { version = "1.1", default-features = false, features = ["v4"] }
-    # NOTE: Generation of UUIDv4 on embedded devices requires a custom implementation
-    #       for getrandom::getrandom. Refer to the following page for more information:
-    #       https://docs.rs/getrandom/latest/getrandom/#unsupported-targets
 
 [dev-dependencies]
 async-std = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ std = [
     "lazy_static",
     "log",
     "serde/std",
+    "rand/std"
 ]
 defmt = ["dep:defmt"] # Enables defmt for logging in no_std
 
@@ -41,7 +42,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 humantime = { version = "2.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = { version = "0.4", optional = true } # Used only in std
-rand = "0.8.5"
+rand = { version = "0.8.5", default-features = false, features = ["alloc", "getrandom"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then in your code:
 ```rust
 use uhlc::*;
 
-// create an HLC with a generated UUID and relying on SystemTime::now()
+// create an HLC with a random u128 and relying on SystemTime::now()
 let hlc = HLC::default();
 
 // generate a timestamp
@@ -44,7 +44,7 @@ You can find more detailled explanations in:
 
 ## Why "Unique" ?
 In this implementation, each HLC instance is associated with an identifier that must be
-unique accross the system (by default a UUIDv4). Each generated timestamp, in addition
+unique accross the system (by default a random u128). Each generated timestamp, in addition
 of the hybrid time, contains the identifier of the HLC that generated it, and it
 therefore unique across the system.
 
@@ -67,7 +67,7 @@ be correlated. I.e.:
    between those events (one is not a consequence of the other).
 
 ## Implementation details
-The `uhlc::HLC::default()` operation generate an UUIDv4 as identifier and uses
+The `uhlc::HLC::default()` operation generate a random u128 as identifier and uses
 `std::time::SystemTime::now()` as physical clock.  
 But using the `uhlc::HLCBuilder` allows you to configure the `HLC` differently. Example:  
 ```Rust

--- a/src/id.rs
+++ b/src/id.rs
@@ -50,21 +50,33 @@ use serde::{Deserialize, Serialize};
 pub struct ID(NonZeroU128);
 
 impl ID {
-    /// The maximum size of an ID in bytes: 16.
+    /// The maximum size of an le-encoded [`ID`](`ID`) in bytes: 16.
     pub const MAX_SIZE: usize = u128::BITS as usize / 8;
 
-    /// The size of this ID in bytes
+    /// The size of this [`ID`](`ID`) in bytes. I.e., the number of significant bytes of the le-encoded [`ID`](`ID`).
     #[inline]
     pub fn size(&self) -> usize {
         Self::MAX_SIZE - (self.0.get().to_le().leading_zeros() as usize / 8)
     }
 
     /// This ID as bytes
+    ///
+    /// If you want to retrive a le-encoded slice of the [`ID`](`ID`), you can do it as follows:
+    /// ```
+    /// use uhlc::ID;
+    /// use std::convert::TryFrom;
+    ///
+    /// let id = ID::try_from(&[0x01]).unwrap();
+    /// let slice = &id.to_le_bytes()[..id.size()];
+    /// assert_eq!(1, slice.len());
+    /// assert_eq!(&[0x01], slice);
+    /// ```
     #[inline]
     pub fn to_le_bytes(&self) -> [u8; Self::MAX_SIZE] {
         self.0.get().to_le_bytes()
     }
 
+    /// Generate a random [`ID`](`ID`).
     #[inline]
     pub fn rand() -> Self {
         use rand::rngs::OsRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! ```
 //! use uhlc::HLC;
 //!
-//! // create an HLC with a generated UUID and relying on SystemTime::now()
+//! // create an HLC with a generated random ID and relying on SystemTime::now()
 //! let hlc = HLC::default();
 //!
 //! // generate timestamps
@@ -128,7 +128,7 @@ pub struct HLCBuilder {
 impl HLCBuilder {
     ///
     /// Constructs a new HLCBuilder for the creation of an [`HLC`], with the following default configuration:
-    ///  * a random UUID as HLC identifier.
+    ///  * a random u128 as HLC identifier.
     ///   Can be changed calling [`Self::with_id()`].
     ///  * [`system_time_clock()`] as physical clock (i.e. the ).
     ///   Can be changed calling [`Self::with_clock()`].
@@ -178,7 +178,7 @@ impl Default for HLCBuilder {
     fn default() -> Self {
         HLCBuilder {
             hlc: HLC {
-                id: uuid::Uuid::new_v4().into(),
+                id: ID::rand(),
                 #[cfg(feature = "std")]
                 clock: system_time_clock,
                 #[cfg(not(feature = "std"))]
@@ -319,7 +319,7 @@ impl HLC {
 }
 
 impl Default for HLC {
-    /// Create a new [`HLC`] with a generated UUID and using
+    /// Create a new [`HLC`] with a random u128 ID and using
     /// [`system_time_clock()`] as physical clock.
     /// This is equivalent to `HLCBuilder::default().build()`
     fn default() -> Self {
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn hlc_update_with_timestamp() {
-        let id: ID = ID::from(uuid::Uuid::new_v4());
+        let id: ID = ID::rand();
         let hlc = HLCBuilder::new().with_id(id).build();
 
         // Test that updating with an old Timestamp don't break the HLC


### PR DESCRIPTION
Explicitly make the ID a little endian 128 bit unsigned integer.
Once merged, a new version of uhlc should be published to crates.io.