### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ lazy_static = { version = "1.4.0", optional = true }
 log = { version = "0.4", optional = true } # Used only in std
 rand = { version = "0.8.5", default-features = false, features = ["alloc", "getrandom"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-spin = { version = "0.9", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
+spin = { version = "0.9.8, default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
 
 [dev-dependencies]
 async-std = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ lazy_static = { version = "1.4.0", optional = true }
 log = { version = "0.4", optional = true } # Used only in std
 rand = { version = "0.8.5", default-features = false, features = ["alloc", "getrandom"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-spin = { version = "0.9.8, default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
+spin = { version = "0.9.8", default-features = false, features = ["mutex", "spin_mutex"] } # No_std alternative for std::sync::Mutex
 
 [dev-dependencies]
 async-std = "1.6"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)