### PR TITLE
Change internal representation of ID

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,9 +448,9 @@ mod tests {
             let mut all_times: Vec<Timestamp> = vecs
                 .0
                 .into_iter()
-                .chain(vecs.1.into_iter())
-                .chain(vecs.2.into_iter())
-                .chain(vecs.3.into_iter())
+                .chain(vecs.1)
+                .chain(vecs.2)
+                .chain(vecs.3)
                 .collect::<Vec<Timestamp>>();
             assert_eq!(NB_TIME * 4, all_times.len());
             all_times.sort();


### PR DESCRIPTION
Move from `NonZeroU128` to  `[u8;16]`.

Pros:
- Memory layout guarantees across platforms and compiler versions for FFI

Cons:
- The usage of `NonZeroU128` exploits compiler niche for `Option<NonZeroU128>`. 

Linked PR: https://github.com/eclipse-zenoh/zenoh-c/pull/295